### PR TITLE
chore(ci): upgrade CodeQL SARIF upload action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- use `github/codeql-action/upload-sarif@v3` for security scan

## Testing
- `pnpm lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_b_68b5dfb61f4c832dbfca749bc846bc90